### PR TITLE
show the most frequently used commands

### DIFF
--- a/helpers/scripts/functions/topcmd
+++ b/helpers/scripts/functions/topcmd
@@ -1,4 +1,3 @@
-#!bin/bash
 # shamelessly stolen from https://github.com/abhinav-nath/all-about-shell/blob/master/dev-setup/.functions
 # and then modified by Thomas Bernard (https://github.com/TomfromBerlin) (c)2023
 # Licence: MIT Licence


### PR DESCRIPTION
shebang deleted since it should run in the current shell